### PR TITLE
Improve gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 
-# Created by https://www.toptal.com/developers/gitignore/api/eclipse,intellij,maven,java,intellij+all,intellij+iml
-# Edit at https://www.toptal.com/developers/gitignore?templates=eclipse,intellij,maven,java,intellij+all,intellij+iml
+# Created by https://www.toptal.com/developers/gitignore/api/eclipse,intellij,maven,java,intellij+all,intellij+iml,netbeans
+# Edit at https://www.toptal.com/developers/gitignore?templates=eclipse,intellij,maven,java,intellij+all,intellij+iml,netbeans
 
 ### Eclipse ###
 .metadata
@@ -333,4 +333,14 @@ buildNumber.properties
 # JDT-specific (Eclipse Java Development Tools)
 .classpath
 
-# End of https://www.toptal.com/developers/gitignore/api/eclipse,intellij,maven,java,intellij+all,intellij+iml
+### NetBeans ###
+**/nbproject/private/
+**/nbproject/Makefile-*.mk
+**/nbproject/Package-*.bash
+build/
+nbbuild/
+dist/
+nbdist/
+.nb-gradle/
+
+# End of https://www.toptal.com/developers/gitignore/api/eclipse,intellij,maven,java,intellij+all,intellij+iml,netbeans


### PR DESCRIPTION
As explained in the issue "[Improve .gitignore](https://github.com/lokka30/Treasury/issues/17)", the .gitignore file serves an important role in git development allowing for faster selection of files to commit, removing the need to exclude some files from every commit. However, the one in this repository is vague and only covers the Intell Idea IDE. With this gitignore we would cover Intell Idea, Eclipse, NetBeans, Maven and Java files that are probably not meant to be commited