### PR TITLE
Fix me.lokka30.treasury.api.economy.account.BankAccount#isBankOwner

### DIFF
--- a/src/main/java/me/lokka30/treasury/api/economy/account/BankAccount.java
+++ b/src/main/java/me/lokka30/treasury/api/economy/account/BankAccount.java
@@ -48,7 +48,7 @@ public interface BankAccount extends Account {
      * @return whether the player with specified UUID owns the bank.
      */
     default boolean isBankOwner(@NotNull UUID uuid) {
-        return getOwningPlayerId() == uuid;
+        return getOwningPlayerId().equals(uuid);
     }
 
     /**


### PR DESCRIPTION
The method `me.lokka30.treasury.api.economy.account.BankAccount#isBankOwner` was defined as
``` Java
default boolean isBankOwner(@NotNull UUID uuid) {
    return getOwningPlayerId() == uuid;
}
```
Since UUID is not a primary type comparing them with `==` will compare the memory address represented by the variable, this is however not what we want. For example,
``` Java
UUID owner = ... // owner of the accounr
BankAccount account = ...

// we have saved the owner into a database and now we retreat it
String ownerAsString = ...
UUID ownerFromString = UUID.fromString(ownerAsString);

assertTrue(account.isBankOwner(ownerFromString)); // fails
```
Instead we want to use the `equals` method to make sure we avoid these conflicts. 