### PR TITLE
Deprecation and eventual removal of API Versions

### DIFF
--- a/api/src/main/java/me/lokka30/treasury/api/common/event/Cancellable.java
+++ b/api/src/main/java/me/lokka30/treasury/api/common/event/Cancellable.java
@@ -8,7 +8,7 @@ package me.lokka30.treasury.api.common.event;
  * An interface, which can be implemented by events which should be cancellable.
  *
  * @author MrIvanPlays
- * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#V1_1 v1.1}
+ * @since v1.1.0
  */
 public interface Cancellable {
 

--- a/api/src/main/java/me/lokka30/treasury/api/common/event/Completion.java
+++ b/api/src/main/java/me/lokka30/treasury/api/common/event/Completion.java
@@ -20,7 +20,7 @@ import org.jetbrains.annotations.Nullable;
  *
  * @author MrIvanPlays
  * @see EventSubscriber
- * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#V1_1 v1.1}
+ * @since v1.1.0
  */
 public final class Completion {
 

--- a/api/src/main/java/me/lokka30/treasury/api/common/event/EventBus.java
+++ b/api/src/main/java/me/lokka30/treasury/api/common/event/EventBus.java
@@ -19,7 +19,7 @@ import org.jetbrains.annotations.NotNull;
  * Represents an event bus. An event bus manages event subscriptions and event calls.
  *
  * @author MrIvanPlays
- * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#V1_1 v1.1}
+ * @since v1.1.0
  */
 public enum EventBus {
     INSTANCE;
@@ -102,7 +102,7 @@ public enum EventBus {
      *
      * @param <T> event type
      * @author MrIvanPlays
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#V1_1 v1.1}
+     * @since v1.1.0
      */
     public static final class EventSubscriberBuilder<T> {
 

--- a/api/src/main/java/me/lokka30/treasury/api/common/event/EventPriority.java
+++ b/api/src/main/java/me/lokka30/treasury/api/common/event/EventPriority.java
@@ -8,7 +8,7 @@ package me.lokka30.treasury.api.common.event;
  * Represents a priority of an {@link EventSubscriber}.
  *
  * @author MrIvanPlays
- * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#V1_1 v1.1}
+ * @since v1.1.0
  */
 public enum EventPriority {
 

--- a/api/src/main/java/me/lokka30/treasury/api/common/event/EventSubscriber.java
+++ b/api/src/main/java/me/lokka30/treasury/api/common/event/EventSubscriber.java
@@ -55,7 +55,7 @@ import org.jetbrains.annotations.NotNull;
  *
  * @param <T> event type
  * @author MrIvanPlays
- * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#V1_1 v1.1}
+ * @since v1.1.0
  */
 public abstract class EventSubscriber<T> implements Comparable<EventSubscriber<T>> {
 

--- a/api/src/main/java/me/lokka30/treasury/api/common/event/FireCompletion.java
+++ b/api/src/main/java/me/lokka30/treasury/api/common/event/FireCompletion.java
@@ -18,6 +18,7 @@ import org.jetbrains.annotations.Nullable;
  *
  * @param <T> event type
  * @author MrIvanPlays
+ * @since v1.1.0
  */
 public final class FireCompletion<T> {
 

--- a/api/src/main/java/me/lokka30/treasury/api/common/event/SimpleEventSubscriber.java
+++ b/api/src/main/java/me/lokka30/treasury/api/common/event/SimpleEventSubscriber.java
@@ -41,7 +41,7 @@ import org.jetbrains.annotations.NotNull;
  * @param <T> event type
  * @author MrIvanPlays
  * @see EventSubscriber
- * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#V1_1 v1.1}
+ * @since v1.1.0
  */
 public abstract class SimpleEventSubscriber<T> extends EventSubscriber<T> {
 

--- a/api/src/main/java/me/lokka30/treasury/api/common/misc/TriState.java
+++ b/api/src/main/java/me/lokka30/treasury/api/common/misc/TriState.java
@@ -11,7 +11,7 @@ import org.jetbrains.annotations.Nullable;
  * Represents an enum, containing 3 enum values, representing states, hence the name "TriState".
  *
  * @author MrIvanPlays
- * @since v1.0
+ * @since v1.0.0
  */
 public enum TriState {
     TRUE(true),

--- a/api/src/main/java/me/lokka30/treasury/api/common/response/FailureReason.java
+++ b/api/src/main/java/me/lokka30/treasury/api/common/response/FailureReason.java
@@ -11,7 +11,7 @@ import org.jetbrains.annotations.NotNull;
  * A class that represents a description for a fail-case scenario when an action is attempted.
  *
  * @author creatorfromhell
- * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+ * @since v1.0.0
  */
 public interface FailureReason {
 
@@ -21,7 +21,7 @@ public interface FailureReason {
      * @param description the description behind this {@link FailureReason fail case}
      * @return new failure reason
      * @author MrIvanPlays
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     static FailureReason of(@NotNull String description) {
         Objects.requireNonNull(description, "description");
@@ -33,7 +33,7 @@ public interface FailureReason {
      *
      * @return The description behind this {@link FailureReason fail case}.
      * @author creatorfromhell
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     @NotNull String getDescription();
 

--- a/api/src/main/java/me/lokka30/treasury/api/common/response/Subscriber.java
+++ b/api/src/main/java/me/lokka30/treasury/api/common/response/Subscriber.java
@@ -13,7 +13,7 @@ import org.jetbrains.annotations.NotNull;
  *
  * @param <T> the type of value expected on success
  * @author Jikoo
- * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#V1_1 v1.1}
+ * @since v1.1.0
  */
 public interface Subscriber<T, E extends TreasuryException> {
 
@@ -22,7 +22,7 @@ public interface Subscriber<T, E extends TreasuryException> {
      *
      * @param t the value of the successful invocation
      * @author Jikoo
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#V1_1 v1.1}
+     * @since v1.1.0
      */
     void succeed(@NotNull T t);
 
@@ -31,7 +31,7 @@ public interface Subscriber<T, E extends TreasuryException> {
      *
      * @param exception an {@link E} detailing the reason for failure
      * @author Jikoo
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#V1_1 v1.1}
+     * @since v1.1.0
      */
     void fail(@NotNull E exception);
 
@@ -85,7 +85,7 @@ public interface Subscriber<T, E extends TreasuryException> {
      * @param <T>                the type of value expected by the {@code Subscriber}
      * @return a future awaiting subscriber completion
      * @author Jikoo
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#V1_1 v1.1}
+     * @since v1.1.0
      */
     static <T, E extends TreasuryException> @NotNull CompletableFuture<T> asFuture(@NotNull Consumer<?
             super Subscriber<T,E>> subscriberConsumer) {

--- a/api/src/main/java/me/lokka30/treasury/api/common/response/TreasuryException.java
+++ b/api/src/main/java/me/lokka30/treasury/api/common/response/TreasuryException.java
@@ -9,7 +9,7 @@ import org.jetbrains.annotations.Nullable;
  * <p>For performance reasons, this exception does not fill in the stack trace.
  *
  * @author yannicklamprecht
- * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#V1_1 v1.1}
+ * @since v1.1.0
  */
 public class TreasuryException extends Exception {
 
@@ -19,7 +19,7 @@ public class TreasuryException extends Exception {
      * Construct a new {@code TreasuryException}.
      *
      * @param reason the {@link FailureReason} representing the reason for failure
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#V1_1 v1.1}
+     * @since v1.1.0
      */
     public TreasuryException(@NotNull FailureReason reason) {
         this(reason, reason.getDescription(), null);
@@ -30,7 +30,7 @@ public class TreasuryException extends Exception {
      *
      * @param reason  the {@link FailureReason} representing the reason for failure
      * @param message a more detailed description of the problem
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#V1_1 v1.1}
+     * @since v1.1.0
      */
     public TreasuryException(@NotNull FailureReason reason, @NotNull String message) {
         this(reason, message, null);
@@ -41,7 +41,7 @@ public class TreasuryException extends Exception {
      *
      * @param reason the {@link FailureReason} representing the reason for failure
      * @param cause  the {@link Throwable} representing or causing the problem
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#V1_1 v1.1}
+     * @since v1.1.0
      */
     public TreasuryException(@NotNull FailureReason reason, @NotNull Throwable cause) {
         this(
@@ -57,7 +57,7 @@ public class TreasuryException extends Exception {
      * @param reason  the {@link FailureReason} representing the reason for failure
      * @param message a more detailed description of the problem
      * @param cause   the {@link Throwable} representing or causing the problem
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#V1_1 v1.1}
+     * @since v1.1.0
      */
     public TreasuryException(
             @NotNull FailureReason reason, @NotNull String message, @Nullable Throwable cause
@@ -70,7 +70,7 @@ public class TreasuryException extends Exception {
      * Get a {@link FailureReason} representing why the failure occurred.
      *
      * @return the reason for failure
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#V1_1 v1.1}
+     * @since v1.1.0
      */
     public @NotNull FailureReason getReason() {
         return this.reason;
@@ -80,7 +80,7 @@ public class TreasuryException extends Exception {
      * Get a more detailed description of the reason for failure.
      *
      * @return a more detailed description of the problem
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#V1_1 v1.1}
+     * @since v1.1.0
      */
     @Override
     public @NotNull String getMessage() {

--- a/api/src/main/java/me/lokka30/treasury/api/common/services/Service.java
+++ b/api/src/main/java/me/lokka30/treasury/api/common/services/Service.java
@@ -13,7 +13,7 @@ import org.jetbrains.annotations.NotNull;
  *
  * @param <T> type of the data held
  * @author MrIvanPlays
- * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#V1_1}
+ * @since v1.1.0
  */
 public final class Service<T> implements Comparable<Service<?>>, Supplier<T> {
 

--- a/api/src/main/java/me/lokka30/treasury/api/common/services/ServicePriority.java
+++ b/api/src/main/java/me/lokka30/treasury/api/common/services/ServicePriority.java
@@ -8,7 +8,7 @@ package me.lokka30.treasury.api.common.services;
  * Represents a priority of a service.
  *
  * @author MrIvanPlays
- * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#V1_1}
+ * @since v1.1.0
  */
 public enum ServicePriority {
     HIGH,

--- a/api/src/main/java/me/lokka30/treasury/api/common/services/ServiceProvider.java
+++ b/api/src/main/java/me/lokka30/treasury/api/common/services/ServiceProvider.java
@@ -26,7 +26,7 @@ import org.jetbrains.annotations.NotNull;
  * {@link me.lokka30.treasury.api.economy.EconomyProvider}
  *
  * @author MrIvanPlays
- * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#V1_1}
+ * @since v1.1.0
  */
 public enum ServiceProvider {
     INSTANCE;

--- a/api/src/main/java/me/lokka30/treasury/api/common/services/event/ServiceRegisteredEvent.java
+++ b/api/src/main/java/me/lokka30/treasury/api/common/services/event/ServiceRegisteredEvent.java
@@ -12,7 +12,7 @@ import org.jetbrains.annotations.NotNull;
  * An event, called whenever a {@link Service} has been registered
  *
  * @author MrIvanPlays
- * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#V1_1 v1.1}
+ * @since v1.1.0
  */
 public class ServiceRegisteredEvent {
 

--- a/api/src/main/java/me/lokka30/treasury/api/common/services/event/ServiceUnregisteredEvent.java
+++ b/api/src/main/java/me/lokka30/treasury/api/common/services/event/ServiceUnregisteredEvent.java
@@ -12,7 +12,7 @@ import org.jetbrains.annotations.NotNull;
  * An event, called whenever a {@link Service} has been unregistered
  *
  * @author MrIvanPlays
- * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#V1_1 v1.1}
+ * @since v1.1.0
  */
 public class ServiceUnregisteredEvent {
 

--- a/api/src/main/java/me/lokka30/treasury/api/economy/EconomyProvider.java
+++ b/api/src/main/java/me/lokka30/treasury/api/economy/EconomyProvider.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import me.lokka30.treasury.api.common.misc.TriState;
 import me.lokka30.treasury.api.economy.account.Account;
 import me.lokka30.treasury.api.economy.account.AccountPermission;
 import me.lokka30.treasury.api.economy.account.NonPlayerAccount;
@@ -21,7 +22,6 @@ import me.lokka30.treasury.api.economy.misc.OptionalEconomyApiFeature;
 import me.lokka30.treasury.api.economy.response.EconomyException;
 import me.lokka30.treasury.api.economy.response.EconomyFailureReason;
 import me.lokka30.treasury.api.economy.response.EconomySubscriber;
-import me.lokka30.treasury.api.common.misc.TriState;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -31,11 +31,13 @@ import org.jetbrains.annotations.Nullable;
  * the specific platform they're implementing it for.
  *
  * @author lokka30, Jikoo, MrIvanPlays, NoahvdAa, creatorfromhell
- * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+ * @since v1.0.0
  */
 public interface EconomyProvider {
 
     /**
+     * WARNING: API versions are no longer used as of Treasury v1.1.0. Ignore this method.
+     * 
      * Get the version of the Treasury API the {@code EconomyProvider} is based on.
      *
      * <p>Warning: The Treasury API version is completely different to any other platform version,
@@ -46,9 +48,13 @@ public interface EconomyProvider {
      *
      * @return the API version
      * @author lokka30, MrIvanPlays
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
+     * @deprecated API versions are no longer used as of Treasury v1.1.0.
      */
-    @NotNull EconomyAPIVersion getSupportedAPIVersion();
+    @Deprecated
+    default @NotNull EconomyAPIVersion getSupportedAPIVersion() {
+        return EconomyAPIVersion.getCurrentAPIVersion();
+    }
 
     /**
      * Check which optional Treasury Economy API features the Economy Provider supports.
@@ -67,7 +73,7 @@ public interface EconomyProvider {
      * @return the set of optional supported features from the economy provider/
      * @author lokka30
      * @see OptionalEconomyApiFeature
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     @NotNull Set<OptionalEconomyApiFeature> getSupportedOptionalEconomyApiFeatures();
 
@@ -77,7 +83,7 @@ public interface EconomyProvider {
      * @param accountId    the {@link UUID} of the account owner
      * @param subscription the {@link EconomySubscriber} accepting the resulting value
      * @author Jikoo
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     void hasPlayerAccount(
             @NotNull UUID accountId, @NotNull EconomySubscriber<Boolean> subscription
@@ -89,7 +95,7 @@ public interface EconomyProvider {
      * @param accountId    the {@link UUID} of the account owner
      * @param subscription the {@link EconomySubscriber} accepting the resulting value
      * @author Jikoo
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     void retrievePlayerAccount(
             @NotNull UUID accountId, @NotNull EconomySubscriber<PlayerAccount> subscription
@@ -101,7 +107,7 @@ public interface EconomyProvider {
      * @param accountId    the {@link UUID} of the account owner
      * @param subscription the {@link EconomySubscriber} accepting the resulting value
      * @author Jikoo
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     void createPlayerAccount(
             @NotNull UUID accountId, @NotNull EconomySubscriber<PlayerAccount> subscription
@@ -112,7 +118,7 @@ public interface EconomyProvider {
      *
      * @param subscription the {@link EconomySubscriber} accepting the resulting value
      * @author Jikoo
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     void retrievePlayerAccountIds(@NotNull EconomySubscriber<Collection<UUID>> subscription);
 
@@ -126,7 +132,7 @@ public interface EconomyProvider {
      * @param identifier   the identifier of the account
      * @param subscription the {@link EconomySubscriber} accepting the resulting value
      * @author Jikoo
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     void hasAccount(@NotNull String identifier, @NotNull EconomySubscriber<Boolean> subscription);
 
@@ -140,7 +146,7 @@ public interface EconomyProvider {
      * @param identifier   the identifier of the account
      * @param subscription the {@link EconomySubscriber} accepting the resulting value
      * @author Jikoo
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     void retrieveAccount(
             @NotNull String identifier, @NotNull EconomySubscriber<Account> subscription
@@ -156,7 +162,7 @@ public interface EconomyProvider {
      * @param identifier   the identifier of the account
      * @param subscription the {@link EconomySubscriber} accepting the resulting value
      * @author Jikoo
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     default void createAccount(
             @NotNull String identifier, @NotNull EconomySubscriber<Account> subscription
@@ -176,7 +182,7 @@ public interface EconomyProvider {
      * @param identifier   the unique identifier of the account
      * @param subscription the {@link EconomySubscriber} accepting the resulting value
      * @author MrIvanPlays, Jikoo
-     * @since {@link EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     void createAccount(
             @Nullable String name,
@@ -189,7 +195,7 @@ public interface EconomyProvider {
      *
      * @param subscription the {@link EconomySubscriber} accepting the resulting value
      * @author Jikoo
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     void retrieveAccountIds(@NotNull EconomySubscriber<Collection<String>> subscription);
 
@@ -198,7 +204,7 @@ public interface EconomyProvider {
      *
      * @param subscription the {@link EconomySubscriber} accepting the resulting value
      * @author Jikoo
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     void retrieveNonPlayerAccountIds(@NotNull EconomySubscriber<Collection<String>> subscription);
 
@@ -208,7 +214,7 @@ public interface EconomyProvider {
      * @param playerId     the player
      * @param subscription the {@link EconomySubscriber} accepting the resulting value
      * @author MrNemo64, MrIvanPlays
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     default void retrieveAllAccountsPlayerIsMemberOf(
             @NotNull UUID playerId, @NotNull EconomySubscriber<Collection<String>> subscription
@@ -272,7 +278,7 @@ public interface EconomyProvider {
      * @param permissions  the permissions that the given player has to have on the {@link NonPlayerAccount account}
      * @author MrNemo64, MrIvanPlays
      * @see #retrieveAllAccountsPlayerIsMemberOf(UUID, EconomySubscriber)
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     default void retrieveAllAccountsPlayerHasPermission(
             @NotNull UUID playerId,
@@ -346,7 +352,7 @@ public interface EconomyProvider {
      *
      * @return the primary currency
      * @author Jikoo
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     @NotNull Currency getPrimaryCurrency();
 
@@ -357,7 +363,7 @@ public interface EconomyProvider {
      * @return The {@link Optional} containing the search result. This will contain the
      *         resulting {@link Currency} if it exists, otherwise it will return {@link Optional#empty()}.
      * @author creatorfromhell
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     Optional<Currency> findCurrency(@NotNull String identifier);
 
@@ -366,7 +372,7 @@ public interface EconomyProvider {
      *
      * @return A set of every {@link Currency} object that is available for the server.
      * @author creatorfromhell
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     Set<Currency> getCurrencies();
 
@@ -375,7 +381,7 @@ public interface EconomyProvider {
      *
      * @return the String identifier identifying the primary currency
      * @author lokka30
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     @NotNull
     default String getPrimaryCurrencyId() {
@@ -392,7 +398,7 @@ public interface EconomyProvider {
      *                     This will be {@link Boolean#TRUE} if it was registered, otherwise
      *                     it'll be {@link Boolean#FALSE}.
      * @author creatorfromhell
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     void registerCurrency(
             @NotNull Currency currency, @NotNull EconomySubscriber<Boolean> subscription

--- a/api/src/main/java/me/lokka30/treasury/api/economy/account/Account.java
+++ b/api/src/main/java/me/lokka30/treasury/api/economy/account/Account.java
@@ -11,6 +11,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import me.lokka30.treasury.api.common.misc.TriState;
 import me.lokka30.treasury.api.economy.EconomyProvider;
 import me.lokka30.treasury.api.economy.currency.Currency;
 import me.lokka30.treasury.api.economy.response.EconomyException;
@@ -19,7 +20,6 @@ import me.lokka30.treasury.api.economy.transaction.EconomyTransaction;
 import me.lokka30.treasury.api.economy.transaction.EconomyTransactionImportance;
 import me.lokka30.treasury.api.economy.transaction.EconomyTransactionInitiator;
 import me.lokka30.treasury.api.economy.transaction.EconomyTransactionType;
-import me.lokka30.treasury.api.common.misc.TriState;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -32,7 +32,7 @@ import org.jetbrains.annotations.Nullable;
  * @see EconomyProvider
  * @see PlayerAccount
  * @see NonPlayerAccount
- * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+ * @since v1.0.0
  */
 public interface Account {
 
@@ -41,7 +41,7 @@ public interface Account {
      *
      * @return The String unique identifier for this account.
      * @author creatorfromhell
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     @NotNull String getIdentifier();
 
@@ -52,7 +52,7 @@ public interface Account {
      *
      * @return an optional fulfilled with a name or an empty optional
      * @author MrIvanPlays
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     Optional<String> getName();
 
@@ -62,7 +62,7 @@ public interface Account {
      * @param name         the new name for this account.
      * @param subscription the {@link EconomySubscriber} accepting whether name change was successful
      * @author MrIvanPlays
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     void setName(@Nullable String name, @NotNull EconomySubscriber<Boolean> subscription);
 
@@ -73,7 +73,7 @@ public interface Account {
      * @param subscription the {@link EconomySubscriber} accepting the amount
      * @author lokka30, Geolykt, creatorfromhell
      * @see Account#setBalance(BigDecimal, EconomyTransactionInitiator, Currency, EconomySubscriber)
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     void retrieveBalance(
             @NotNull Currency currency, @NotNull EconomySubscriber<BigDecimal> subscription
@@ -88,7 +88,7 @@ public interface Account {
      * @param subscription the {@link EconomySubscriber} accepting the new balance
      * @author lokka30, Geolykt, MrIvanPlays, creatorfromhell
      * @see Account#retrieveBalance(Currency, EconomySubscriber)
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     void setBalance(
             @NotNull BigDecimal amount,
@@ -107,7 +107,7 @@ public interface Account {
      * @author lokka30, Geolykt, MrIvanPlays, creatorfromhell
      * @see Account#setBalance(BigDecimal, EconomyTransactionInitiator, Currency, EconomySubscriber)
      * @see Account#doTransaction(EconomyTransaction, EconomySubscriber)
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     default void withdrawBalance(
             @NotNull BigDecimal amount,
@@ -136,7 +136,7 @@ public interface Account {
      * @author lokka30, Geolykt, MrIvanPlays, creatorfromhell
      * @see Account#setBalance(BigDecimal, EconomyTransactionInitiator, Currency, EconomySubscriber)
      * @see Account#doTransaction(EconomyTransaction, EconomySubscriber)
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     default void withdrawBalance(
             @NotNull BigDecimal amount,
@@ -160,7 +160,7 @@ public interface Account {
      * @author MrIvanPlays, creatorfromhell
      * @see Account#setBalance(BigDecimal, EconomyTransactionInitiator, Currency, EconomySubscriber)
      * @see Account#doTransaction(EconomyTransaction, EconomySubscriber)
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     default void withdrawBalance(
             @NotNull BigDecimal amount,
@@ -191,7 +191,7 @@ public interface Account {
      * @author lokka30, MrIvanPlays, creatorfromhell
      * @see Account#setBalance(BigDecimal, EconomyTransactionInitiator, Currency, EconomySubscriber)
      * @see Account#doTransaction(EconomyTransaction, EconomySubscriber)
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     default void depositBalance(
             @NotNull BigDecimal amount,
@@ -220,7 +220,7 @@ public interface Account {
      * @author lokka30, MrIvanPlays, creatorfromhell
      * @see Account#setBalance(BigDecimal, EconomyTransactionInitiator, Currency, EconomySubscriber)
      * @see Account#doTransaction(EconomyTransaction, EconomySubscriber)
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     default void depositBalance(
             @NotNull BigDecimal amount,
@@ -244,7 +244,7 @@ public interface Account {
      * @author MrIvanPlays, creatorfromhell
      * @see Account#setBalance(BigDecimal, EconomyTransactionInitiator, Currency, EconomySubscriber)
      * @see Account#doTransaction(EconomyTransaction, EconomySubscriber)
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     default void depositBalance(
             @NotNull BigDecimal amount,
@@ -272,7 +272,7 @@ public interface Account {
      * @param subscription       the {@link EconomySubscriber} accepting the new balance
      * @author MrIvanPlays, creatorfromhell
      * @see Account#setBalance(BigDecimal, EconomyTransactionInitiator, Currency, EconomySubscriber)
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     void doTransaction(
             @NotNull EconomyTransaction economyTransaction,
@@ -290,7 +290,7 @@ public interface Account {
      * @author lokka30, Geolykt, MrIvanPlays, creatorfromhell
      * @see PlayerAccount#resetBalance(EconomyTransactionInitiator, Currency, EconomySubscriber)
      * @see Account#setBalance(BigDecimal, EconomyTransactionInitiator, Currency, EconomySubscriber)
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     default void resetBalance(
             @NotNull EconomyTransactionInitiator<?> initiator,
@@ -318,7 +318,7 @@ public interface Account {
      * @param subscription the {@link EconomySubscriber} accepting whether the balance is high enough
      * @author lokka30, Geolykt
      * @see Account#retrieveBalance(Currency, EconomySubscriber)
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     default void canAfford(
             @NotNull BigDecimal amount,
@@ -345,7 +345,7 @@ public interface Account {
      *
      * @param subscription the {@link EconomySubscriber} accepting whether deletion occurred successfully
      * @author lokka30
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     void deleteAccount(@NotNull EconomySubscriber<Boolean> subscription);
 
@@ -354,7 +354,7 @@ public interface Account {
      *
      * @param subscription the {@link EconomySubscriber} accepting the currencies
      * @author MrIvanPlays
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     void retrieveHeldCurrencies(@NotNull EconomySubscriber<Collection<String>> subscription);
 
@@ -372,7 +372,7 @@ public interface Account {
      * @param to               the timestamp to get the transactions to
      * @param subscription     the {@link EconomySubscriber} accepting the transaction history
      * @author MrIvanPlays
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     void retrieveTransactionHistory(
             int transactionCount,
@@ -390,7 +390,7 @@ public interface Account {
      * @param transactionCount the count of the transactions wanted
      * @param subscription     the {@link EconomySubscriber} accepting the transaction history
      * @author MrIvanPlays
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     default void retrieveTransactionHistory(
             int transactionCount,
@@ -404,7 +404,7 @@ public interface Account {
      *
      * @param subscription the {@link EconomySubscriber} accepting the members
      * @author lokka30
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     void retrieveMemberIds(@NotNull EconomySubscriber<Collection<UUID>> subscription);
 
@@ -416,7 +416,7 @@ public interface Account {
      * @param player       the {@link UUID} of the potential member
      * @param subscription the {@link EconomySubscriber} accepting whether the user is a member
      * @author lokka30
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     void isMember(@NotNull UUID player, @NotNull EconomySubscriber<Boolean> subscription);
 
@@ -433,7 +433,7 @@ public interface Account {
      *                        member were adjusted.
      * @param permissions     the permissions to modify
      * @author MrIvanPlays
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     void setPermission(
             @NotNull UUID player,
@@ -449,7 +449,7 @@ public interface Account {
      * @param player       the player {@link UUID} to get the permissions for
      * @param subscription the {@link EconomySubscriber} accepting an immutable map of permissions and their values.
      * @author MrIvanPlays
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     void retrievePermissions(
             @NotNull UUID player,
@@ -466,7 +466,7 @@ public interface Account {
      * @param permissions  the permissions to check
      * @author MrNemo64, MrIvanPlays
      * @see AccountPermission
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     void hasPermission(
             @NotNull UUID player,

--- a/api/src/main/java/me/lokka30/treasury/api/economy/account/AccountPermission.java
+++ b/api/src/main/java/me/lokka30/treasury/api/economy/account/AccountPermission.java
@@ -6,17 +6,17 @@ package me.lokka30.treasury.api.economy.account;
 
 import java.math.BigDecimal;
 import java.util.UUID;
+import me.lokka30.treasury.api.common.misc.TriState;
 import me.lokka30.treasury.api.economy.currency.Currency;
 import me.lokka30.treasury.api.economy.response.EconomySubscriber;
 import me.lokka30.treasury.api.economy.transaction.EconomyTransactionInitiator;
-import me.lokka30.treasury.api.common.misc.TriState;
 
 /**
  * Enum that holds the permissions of an {@link Account} that is shared among multiple players.
  *
  * @author MrNemo64
  * @see Account
- * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+ * @since v1.0.0
  */
 public enum AccountPermission {
 
@@ -24,7 +24,7 @@ public enum AccountPermission {
      * Allows a player to see the balance of the {@link Account}.
      *
      * @see Account#retrieveBalance(Currency, EconomySubscriber)
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     BALANCE,
 
@@ -32,7 +32,7 @@ public enum AccountPermission {
      * Allows a player to withdraw from the {@link Account}.
      *
      * @see Account#withdrawBalance(BigDecimal, EconomyTransactionInitiator, Currency, EconomySubscriber)
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     WITHDRAW,
 
@@ -40,7 +40,7 @@ public enum AccountPermission {
      * Allows a player to deposit on the {@link Account}.
      *
      * @see Account#depositBalance(BigDecimal, EconomyTransactionInitiator, Currency, EconomySubscriber)
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     DEPOSIT,
 
@@ -48,7 +48,7 @@ public enum AccountPermission {
      * Allows a player to modify the permissions of other players on a {@link Account}
      *
      * @see NonPlayerAccount#setPermission(UUID, TriState, EconomySubscriber, AccountPermission...)
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     MODIFY_PERMISSIONS
 }

--- a/api/src/main/java/me/lokka30/treasury/api/economy/account/NonPlayerAccount.java
+++ b/api/src/main/java/me/lokka30/treasury/api/economy/account/NonPlayerAccount.java
@@ -10,7 +10,7 @@ package me.lokka30.treasury.api.economy.account;
  *
  * @author lokka30, MrNemo64
  * @see Account
- * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+ * @since v1.0.0
  */
 public interface NonPlayerAccount extends Account {
 

--- a/api/src/main/java/me/lokka30/treasury/api/economy/account/PlayerAccount.java
+++ b/api/src/main/java/me/lokka30/treasury/api/economy/account/PlayerAccount.java
@@ -14,7 +14,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import me.lokka30.treasury.api.common.misc.TriState;
 import me.lokka30.treasury.api.economy.currency.Currency;
-import me.lokka30.treasury.api.economy.misc.EconomyAPIVersion;
 import me.lokka30.treasury.api.economy.response.EconomyException;
 import me.lokka30.treasury.api.economy.response.EconomyFailureReason;
 import me.lokka30.treasury.api.economy.response.EconomySubscriber;
@@ -32,7 +31,7 @@ import org.jetbrains.annotations.Nullable;
  *
  * @author lokka30, Geolykt, creatorfromhell
  * @see Account
- * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+ * @since v1.0.0
  */
 public interface PlayerAccount extends Account {
 
@@ -49,7 +48,7 @@ public interface PlayerAccount extends Account {
      *
      * @return The String unique identifier for this account.
      * @author creatorfromhell
-     * @since {@link EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     @Override
     default @NotNull String getIdentifier() {
@@ -72,7 +71,7 @@ public interface PlayerAccount extends Account {
      * @return uuid of the Account.
      * @author lokka30
      * @see UUID
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     @NotNull UUID getUniqueId();
 
@@ -153,7 +152,7 @@ public interface PlayerAccount extends Account {
      * @param subscription the {@link EconomySubscriber} accepting the new balance
      * @author lokka30, MrIvanPlays, creatorfromhell
      * @see Account#resetBalance(EconomyTransactionInitiator, Currency, EconomySubscriber)
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     @Override
     default void resetBalance(

--- a/api/src/main/java/me/lokka30/treasury/api/economy/currency/Currency.java
+++ b/api/src/main/java/me/lokka30/treasury/api/economy/currency/Currency.java
@@ -21,7 +21,7 @@ import org.jetbrains.annotations.Nullable;
  * economy.
  *
  * @author creatorfromhell, lokka30
- * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+ * @since v1.0.0
  */
 public interface Currency {
 
@@ -30,7 +30,7 @@ public interface Currency {
      *
      * @return A unique non-user friendly identifier for the currency.
      * @author creatorfromhell
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     @NotNull String getIdentifier();
 
@@ -39,7 +39,7 @@ public interface Currency {
      *
      * @return The currency's symbol.
      * @author creatorfromhell
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     @NotNull String getSymbol();
 
@@ -48,7 +48,7 @@ public interface Currency {
      *
      * @return The currency's decimal character.
      * @author creatorfromhell
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     char getDecimal();
 
@@ -58,7 +58,7 @@ public interface Currency {
      *
      * @return The currency's user-friendly display name.
      * @author creatorfromhell
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     @NotNull String getDisplayNameSingular();
 
@@ -70,7 +70,7 @@ public interface Currency {
      *
      * @return The plural form of the currency's user-friendly display name.
      * @author creatorfromhell
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     @NotNull String getDisplayNamePlural();
 
@@ -79,7 +79,7 @@ public interface Currency {
      *
      * @return The currency's default number of decimal digits when formatting this currency.
      * @author creatorfromhell
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     int getPrecision();
 
@@ -90,7 +90,7 @@ public interface Currency {
      *         context if multi-world support is not present, otherwise it should use the default world
      *         for this check.
      * @author creatorfromhell
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     boolean isPrimary();
 
@@ -103,7 +103,7 @@ public interface Currency {
      * @param subscription The {@link EconomySubscriber} accepting the resulting {@link BigDecimal} that
      *                     represents the converted amount of the specified {@link Currency}.
      * @author creatorfromhell
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     void to(
             @NotNull Currency currency,
@@ -123,7 +123,7 @@ public interface Currency {
      *                     represents the deformatted amount of the formatted String.
      * @author creatorfromhell
      * @see me.lokka30.treasury.api.economy.response.EconomyFailureReason#NUMBER_PARSING_ERROR
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     void parse(@NotNull String formatted, @NotNull EconomySubscriber<BigDecimal> subscription);
 
@@ -136,7 +136,7 @@ public interface Currency {
      *                 player), then specify {@code null} for this parameter.
      * @return The starting balance of the player for this currency.
      * @author creatorfromhell
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     @NotNull BigDecimal getStartingBalance(@Nullable UUID playerID);
 
@@ -149,7 +149,7 @@ public interface Currency {
      *               {@code null} if the provider should provide their 'default' Locale.
      * @return The formatted text.
      * @author creatorfromhell
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     @NotNull String format(@NotNull BigDecimal amount, @Nullable Locale locale);
 
@@ -163,7 +163,7 @@ public interface Currency {
      * @param precision The amount of decimal digits to use when formatting.
      * @return The formatted text.
      * @author creatorfromhell
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     @NotNull String format(@NotNull BigDecimal amount, @Nullable Locale locale, int precision);
 

--- a/api/src/main/java/me/lokka30/treasury/api/economy/events/AccountTransactionEvent.java
+++ b/api/src/main/java/me/lokka30/treasury/api/economy/events/AccountTransactionEvent.java
@@ -13,7 +13,7 @@ import org.jetbrains.annotations.NotNull;
  * Represents an event, called when an account does a {@link EconomyTransaction}
  *
  * @author lokka30, MrNemo64, MrIvanPlays
- * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#V1_1 v1.1}
+ * @since v1.1.0
  */
 public class AccountTransactionEvent implements Cancellable {
 

--- a/api/src/main/java/me/lokka30/treasury/api/economy/events/NonPlayerAccountTransactionEvent.java
+++ b/api/src/main/java/me/lokka30/treasury/api/economy/events/NonPlayerAccountTransactionEvent.java
@@ -12,7 +12,7 @@ import org.jetbrains.annotations.NotNull;
  * Represents an event, called when a {@link NonPlayerAccount} does a {@link EconomyTransaction}
  *
  * @author lokka30, MrIvanPlays
- * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#V1_1 v1.1}
+ * @since v1.1.0
  */
 public class NonPlayerAccountTransactionEvent extends AccountTransactionEvent {
 

--- a/api/src/main/java/me/lokka30/treasury/api/economy/events/PlayerAccountTransactionEvent.java
+++ b/api/src/main/java/me/lokka30/treasury/api/economy/events/PlayerAccountTransactionEvent.java
@@ -12,7 +12,7 @@ import org.jetbrains.annotations.NotNull;
  * Represents an event, called when a {@link PlayerAccount} does a {@link EconomyTransaction}
  *
  * @author lokka30, MrIvanPlays
- * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#V1_1 v1.1}
+ * @since v1.1.0
  */
 public class PlayerAccountTransactionEvent extends AccountTransactionEvent {
 

--- a/api/src/main/java/me/lokka30/treasury/api/economy/misc/EconomyAPIVersion.java
+++ b/api/src/main/java/me/lokka30/treasury/api/economy/misc/EconomyAPIVersion.java
@@ -8,8 +8,10 @@ package me.lokka30.treasury.api.economy.misc;
  * Represents the current API version.
  *
  * @author lokka30, MrIvanPlays
- * @since v1.0
+ * @since v1.0.0
+ * @deprecated API versions are no longer used as of Treasury v1.1.0.
  */
+@Deprecated
 public enum EconomyAPIVersion {
     v1_0(new short[]{1, 0}),
     V1_1(new short[]{1, 1});

--- a/api/src/main/java/me/lokka30/treasury/api/economy/misc/OptionalEconomyApiFeature.java
+++ b/api/src/main/java/me/lokka30/treasury/api/economy/misc/OptionalEconomyApiFeature.java
@@ -8,7 +8,7 @@ package me.lokka30.treasury.api.economy.misc;
  * Economy Providers may support these specific features at their own option.
  *
  * @author lokka30
- * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+ * @since v1.0.0
  */
 public enum OptionalEconomyApiFeature {
 
@@ -20,7 +20,7 @@ public enum OptionalEconomyApiFeature {
      * platform should not support this feature.
      *
      * @see me.lokka30.treasury.api.economy.event
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      * @deprecated use {@link #TRANSACTION_EVENTS}
      */
     @Deprecated
@@ -31,7 +31,7 @@ public enum OptionalEconomyApiFeature {
      * AccountTransaction events when transactions occur.
      *
      * @see me.lokka30.treasury.api.economy.events
-     * @since {@link EconomyAPIVersion#V1_1 v1.1}
+     * @since v1.1.0
      */
     TRANSACTION_EVENTS,
 
@@ -39,7 +39,7 @@ public enum OptionalEconomyApiFeature {
      * Represents that the Economy Provider supports managing
      * balances of all accounts with negative (below-zero) balances.
      *
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     NEGATIVE_BALANCES
 

--- a/api/src/main/java/me/lokka30/treasury/api/economy/response/EconomyException.java
+++ b/api/src/main/java/me/lokka30/treasury/api/economy/response/EconomyException.java
@@ -14,7 +14,7 @@ import org.jetbrains.annotations.Nullable;
  *
  * <p>For performance reasons, this exception does not fill in the stack trace.
  *
- * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+ * @since v1.0.0
  */
 public class EconomyException extends TreasuryException {
 
@@ -22,7 +22,7 @@ public class EconomyException extends TreasuryException {
      * Construct a new {@code EconomyException}.
      *
      * @param reason the {@link FailureReason} representing the reason for failure
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     public EconomyException(@NotNull FailureReason reason) {
         this(reason, reason.getDescription(), null);
@@ -33,7 +33,7 @@ public class EconomyException extends TreasuryException {
      *
      * @param reason  the {@link FailureReason} representing the reason for failure
      * @param message a more detailed description of the problem
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     public EconomyException(@NotNull FailureReason reason, @NotNull String message) {
         this(reason, message, null);
@@ -44,7 +44,7 @@ public class EconomyException extends TreasuryException {
      *
      * @param reason the {@link FailureReason} representing the reason for failure
      * @param cause  the {@link Throwable} representing or causing the problem
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     public EconomyException(@NotNull FailureReason reason, @NotNull Throwable cause) {
         this(
@@ -60,7 +60,7 @@ public class EconomyException extends TreasuryException {
      * @param reason  the {@link FailureReason} representing the reason for failure
      * @param message a more detailed description of the problem
      * @param cause   the {@link Throwable} representing or causing the problem
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     public EconomyException(
             @NotNull FailureReason reason, @NotNull String message, @Nullable Throwable cause

--- a/api/src/main/java/me/lokka30/treasury/api/economy/response/EconomyFailureReason.java
+++ b/api/src/main/java/me/lokka30/treasury/api/economy/response/EconomyFailureReason.java
@@ -2,13 +2,13 @@ package me.lokka30.treasury.api.economy.response;
 
 import java.math.BigDecimal;
 import java.util.UUID;
+import me.lokka30.treasury.api.common.misc.TriState;
 import me.lokka30.treasury.api.common.response.FailureReason;
 import me.lokka30.treasury.api.economy.EconomyProvider;
 import me.lokka30.treasury.api.economy.account.AccountPermission;
 import me.lokka30.treasury.api.economy.account.PlayerAccount;
 import me.lokka30.treasury.api.economy.currency.Currency;
 import me.lokka30.treasury.api.economy.transaction.EconomyTransactionInitiator;
-import me.lokka30.treasury.api.common.misc.TriState;
 import org.jetbrains.annotations.NotNull;
 
 public enum EconomyFailureReason implements FailureReason {
@@ -22,7 +22,7 @@ public enum EconomyFailureReason implements FailureReason {
      * inside the set obtained from
      * {@link EconomyProvider#getSupportedOptionalEconomyApiFeatures()}.
      *
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     FEATURE_NOT_SUPPORTED {
         /**
@@ -40,7 +40,7 @@ public enum EconomyFailureReason implements FailureReason {
      * To avoid this failure, the server owner should suspend any activities whilst migrating
      * between economy providers.
      *
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     MIGRATION {
         /**
@@ -58,7 +58,7 @@ public enum EconomyFailureReason implements FailureReason {
      * "Request cancellation" could be anything that results in a request being cancelled, server
      * shutdown, thread interruption, etc.
      *
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     REQUEST_CANCELLED {
         /**
@@ -80,7 +80,7 @@ public enum EconomyFailureReason implements FailureReason {
      * @see EconomyProvider#hasPlayerAccount(UUID, EconomySubscriber)
      * @see EconomyProvider#retrieveAccount(String, EconomySubscriber)
      * @see EconomyProvider#retrievePlayerAccount(UUID, EconomySubscriber)
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     ACCOUNT_NOT_FOUND {
         /**
@@ -104,7 +104,7 @@ public enum EconomyFailureReason implements FailureReason {
      * @see EconomyProvider#createAccount(String, EconomySubscriber)
      * @see EconomyProvider#createAccount(String, String, EconomySubscriber)
      * @see EconomyProvider#createPlayerAccount(UUID, EconomySubscriber)
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     ACCOUNT_ALREADY_EXISTS {
         /**
@@ -123,7 +123,7 @@ public enum EconomyFailureReason implements FailureReason {
      * To avoid this failure, do not try to set permissions on player accounts.
      *
      * @see PlayerAccount#setPermission(UUID, TriState, EconomySubscriber, AccountPermission...)
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     PLAYER_ACCOUNT_PERMISSION_MODIFICATION_NOT_SUPPORTED {
         /**
@@ -144,7 +144,7 @@ public enum EconomyFailureReason implements FailureReason {
      *
      * @see EconomyProvider#getSupportedOptionalEconomyApiFeatures()
      * @see me.lokka30.treasury.api.economy.misc.OptionalEconomyApiFeature#NEGATIVE_BALANCES
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     NEGATIVE_BALANCES_NOT_SUPPORTED {
         /**
@@ -164,7 +164,7 @@ public enum EconomyFailureReason implements FailureReason {
      *
      * @see me.lokka30.treasury.api.economy.account.Account#withdrawBalance(BigDecimal, EconomyTransactionInitiator, Currency, EconomySubscriber)
      * @see me.lokka30.treasury.api.economy.account.Account#depositBalance(BigDecimal, EconomyTransactionInitiator, Currency, EconomySubscriber)
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     NEGATIVE_AMOUNT_SPECIFIED {
         /**
@@ -180,7 +180,7 @@ public enum EconomyFailureReason implements FailureReason {
      * A constant representing failure due to the inability to locate a {@link Currency Currency}.
      * To avoid this failure, check if a currency exists before attempting to use it.
      *
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     CURRENCY_NOT_FOUND {
         /**
@@ -198,7 +198,7 @@ public enum EconomyFailureReason implements FailureReason {
      * To avoid this failure, check if a currency exists before attempting to register it.
      *
      * @see me.lokka30.treasury.api.economy.EconomyProvider#registerCurrency(Currency, EconomySubscriber)
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     CURRENCY_ALREADY_REGISTERED {
         /**
@@ -214,7 +214,7 @@ public enum EconomyFailureReason implements FailureReason {
      * A constant representing failure due to a null parameter
      * being specified when a null parameter was not expected.
      *
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     NULL_PARAMETER {
         /**
@@ -232,7 +232,7 @@ public enum EconomyFailureReason implements FailureReason {
      * to parse it into a number type such as {@link BigDecimal}.
      *
      * @see Currency#parse(String, EconomySubscriber)
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     NUMBER_PARSING_ERROR {
         /**
@@ -251,7 +251,7 @@ public enum EconomyFailureReason implements FailureReason {
      * submit a pull request or issue so that a future Treasury version
      * can accommodate for this issue.
      *
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     OTHER_FAILURE {
         /**

--- a/api/src/main/java/me/lokka30/treasury/api/economy/response/EconomySubscriber.java
+++ b/api/src/main/java/me/lokka30/treasury/api/economy/response/EconomySubscriber.java
@@ -64,7 +64,7 @@ import org.jetbrains.annotations.NotNull;
  *
  * @param <T> the type of value expected on success
  * @author Jikoo
- * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+ * @since v1.0.0
  */
 public interface EconomySubscriber<T> extends Subscriber<T, EconomyException> {
 
@@ -118,7 +118,7 @@ public interface EconomySubscriber<T> extends Subscriber<T, EconomyException> {
      * @param <T>                the type of value expected by the {@code EconomySubscriber}
      * @return a future awaiting subscriber completion
      * @author Jikoo
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     static <T> @NotNull CompletableFuture<T> asFuture(
             @NotNull Consumer<EconomySubscriber<T>>

--- a/api/src/main/java/me/lokka30/treasury/api/economy/transaction/EconomyTransaction.java
+++ b/api/src/main/java/me/lokka30/treasury/api/economy/transaction/EconomyTransaction.java
@@ -20,7 +20,7 @@ import org.jetbrains.annotations.Nullable;
  * {@link EconomyTransactionType#WITHDRAWAL}.
  *
  * @author lokka30, MrIvanPlays
- * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+ * @since v1.0.0
  */
 public class EconomyTransaction {
 
@@ -50,7 +50,7 @@ public class EconomyTransaction {
      * @param economyTransactionType the transaction type
      * @param reason                 optional specification of a string message reason
      * @param transactionAmount      the amount which to deposit/withdraw
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     public EconomyTransaction(
             @NotNull String currencyID,
@@ -78,7 +78,7 @@ public class EconomyTransaction {
      * Get the transaction amount.
      *
      * @return transaction amount
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     public BigDecimal getTransactionAmount() {
         return transactionAmount;
@@ -88,7 +88,7 @@ public class EconomyTransaction {
      * Returns the transaction type.
      *
      * @return transaction type
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     @NotNull
     public EconomyTransactionType getTransactionType() {
@@ -103,7 +103,7 @@ public class EconomyTransaction {
      * you need such.
      *
      * @return The currency {@link Currency#getIdentifier() identifier}.
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     @NotNull
     public String getCurrencyID() {

--- a/api/src/main/java/me/lokka30/treasury/api/economy/transaction/EconomyTransactionImportance.java
+++ b/api/src/main/java/me/lokka30/treasury/api/economy/transaction/EconomyTransactionImportance.java
@@ -8,7 +8,7 @@ package me.lokka30.treasury.api.economy.transaction;
  * installed that frequently send low-importance transactions.
  *
  * @author Nemo_64, lokka30
- * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+ * @since v1.0.0
  */
 public enum EconomyTransactionImportance {
 
@@ -19,7 +19,7 @@ public enum EconomyTransactionImportance {
      * Example transaction: {@code Notch} earns {@code $0.23} from mining a {@code Diamond Ore}
      * block.
      *
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     LOW,
 
@@ -28,7 +28,7 @@ public enum EconomyTransactionImportance {
      * Most transactions shall fall under this importance.
      * Example transaction: {@code Dinnerbone} earns {@code $30} from completing a farming quest.
      *
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     NORMAL,
 
@@ -37,7 +37,7 @@ public enum EconomyTransactionImportance {
      * It is suggested that the economy provider stores these transactions for as long as feasible.
      * Example transaction: {@code jeb_} earns {@code $50} from a payment sent by {@code Notch}.
      *
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     HIGH
 }

--- a/api/src/main/java/me/lokka30/treasury/api/economy/transaction/EconomyTransactionType.java
+++ b/api/src/main/java/me/lokka30/treasury/api/economy/transaction/EconomyTransactionType.java
@@ -9,21 +9,21 @@ package me.lokka30.treasury.api.economy.transaction;
  *
  * @author lokka30
  * @see EconomyTransaction
- * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+ * @since v1.0.0
  */
 public enum EconomyTransactionType {
 
     /**
      * The Account's new balance is greater than their previous balance.
      *
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     DEPOSIT,
 
     /**
      * The Account's new balance is less than their previous balance.
      *
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     WITHDRAWAL
 

--- a/api/src/test/java/me/lokka30/treasury/api/common/response/SubscriberTest.java
+++ b/api/src/test/java/me/lokka30/treasury/api/common/response/SubscriberTest.java
@@ -1,14 +1,10 @@
 package me.lokka30.treasury.api.common.response;
 
-import me.lokka30.treasury.api.economy.response.EconomyException;
-import me.lokka30.treasury.api.economy.response.EconomySubscriber;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
-
-import static org.junit.jupiter.api.Assertions.*;
+import me.lokka30.treasury.api.economy.response.EconomyException;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 class SubscriberTest {
 

--- a/core/src/main/java/me/lokka30/treasury/plugin/core/command/subcommand/InfoSubcommand.java
+++ b/core/src/main/java/me/lokka30/treasury/plugin/core/command/subcommand/InfoSubcommand.java
@@ -4,7 +4,6 @@
 
 package me.lokka30.treasury.plugin.core.command.subcommand;
 
-import me.lokka30.treasury.api.economy.misc.EconomyAPIVersion;
 import me.lokka30.treasury.plugin.core.TreasuryPlugin;
 import me.lokka30.treasury.plugin.core.command.CommandSource;
 import me.lokka30.treasury.plugin.core.command.Subcommand;
@@ -46,7 +45,6 @@ public class InfoSubcommand implements Subcommand {
                 placeholder("version", main.getVersion()),
                 placeholder("description", TreasuryPlugin.DESCRIPTION),
                 placeholder("credits", "https://github.com/lokka30/Treasury/wiki/Credits"),
-                placeholder("current-api-version", EconomyAPIVersion.getCurrentAPIVersion()),
                 placeholder("repository", "https://github.com/lokka30/Treasury/")
         ));
 

--- a/core/src/main/java/me/lokka30/treasury/plugin/core/command/subcommand/economy/migrate/MigrationEconomy.java
+++ b/core/src/main/java/me/lokka30/treasury/plugin/core/command/subcommand/economy/migrate/MigrationEconomy.java
@@ -16,7 +16,6 @@ import me.lokka30.treasury.api.economy.EconomyProvider;
 import me.lokka30.treasury.api.economy.account.Account;
 import me.lokka30.treasury.api.economy.account.PlayerAccount;
 import me.lokka30.treasury.api.economy.currency.Currency;
-import me.lokka30.treasury.api.economy.misc.EconomyAPIVersion;
 import me.lokka30.treasury.api.economy.misc.OptionalEconomyApiFeature;
 import me.lokka30.treasury.api.economy.response.EconomyException;
 import me.lokka30.treasury.api.economy.response.EconomyFailureReason;
@@ -120,12 +119,6 @@ class MigrationEconomy implements EconomyProvider {
                 "Economy unavailable during migration process."
         );
 
-    }
-
-    @Override
-    public @NotNull EconomyAPIVersion getSupportedAPIVersion() {
-        //noinspection deprecation
-        return EconomyAPIVersion.getCurrentAPIVersion();
     }
 
     @Override

--- a/core/src/main/java/me/lokka30/treasury/plugin/core/command/subcommand/economy/migrate/NonPlayerAccountMigrator.java
+++ b/core/src/main/java/me/lokka30/treasury/plugin/core/command/subcommand/economy/migrate/NonPlayerAccountMigrator.java
@@ -11,13 +11,13 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Phaser;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
+import me.lokka30.treasury.api.common.misc.TriState;
 import me.lokka30.treasury.api.economy.EconomyProvider;
 import me.lokka30.treasury.api.economy.account.Account;
 import me.lokka30.treasury.api.economy.account.AccountPermission;
 import me.lokka30.treasury.api.economy.response.EconomyException;
 import me.lokka30.treasury.api.economy.response.EconomySubscriber;
 import me.lokka30.treasury.api.economy.transaction.EconomyTransactionInitiator;
-import me.lokka30.treasury.api.common.misc.TriState;
 import org.jetbrains.annotations.NotNull;
 
 class NonPlayerAccountMigrator implements AccountMigrator<Account> {

--- a/core/src/main/java/me/lokka30/treasury/plugin/core/utils/UpdateChecker.java
+++ b/core/src/main/java/me/lokka30/treasury/plugin/core/utils/UpdateChecker.java
@@ -11,11 +11,6 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.net.URL;
 import java.time.OffsetDateTime;
-import java.util.Optional;
-import me.lokka30.treasury.api.common.services.Service;
-import me.lokka30.treasury.api.common.services.ServiceProvider;
-import me.lokka30.treasury.api.economy.EconomyProvider;
-import me.lokka30.treasury.api.economy.misc.EconomyAPIVersion;
 import me.lokka30.treasury.plugin.core.TreasuryPlugin;
 
 /**
@@ -132,22 +127,6 @@ public final class UpdateChecker {
             plugin.logger().warn(
                     "You are running a newer version of Treasury than known. How did we get here?");
         }
-
-        Optional<Service<EconomyProvider>> providerEconomyProvider = ServiceProvider.INSTANCE.serviceFor(
-                EconomyProvider.class);
-        if (providerEconomyProvider.isPresent()) {
-            Service<EconomyProvider> service = providerEconomyProvider.get();
-            EconomyProvider provider = service.get();
-            EconomyAPIVersion providerVersion = provider.getSupportedAPIVersion();
-            EconomyAPIVersion latestVersion = EconomyAPIVersion.getCurrentAPIVersion();
-
-            handleAPIVersioning(providerVersion,
-                    latestVersion,
-                    service.registrarName(),
-                    comparisonResult,
-                    currentVersion.isDevelopmentVersion()
-            );
-        }
     }
 
     private static void handleGitHubVersioning(PluginVersion.ComparisonResult comparisonResult) {
@@ -168,86 +147,6 @@ public final class UpdateChecker {
         } else if (comparisonResult == PluginVersion.ComparisonResult.UNKNOWN) {
             plugin.logger().warn(
                     "Couldn't check for a development version update. You are running a development version. Please check for updates and stay updated :).");
-        }
-
-        Optional<Service<EconomyProvider>> providerEconomyProvider = ServiceProvider.INSTANCE.serviceFor(
-                EconomyProvider.class);
-        if (providerEconomyProvider.isPresent()) {
-            Service<EconomyProvider> service = providerEconomyProvider.get();
-            EconomyProvider provider = service.get();
-            EconomyAPIVersion providerVersion = provider.getSupportedAPIVersion();
-            EconomyAPIVersion latestVersion = EconomyAPIVersion.getCurrentAPIVersion();
-
-            handleAPIVersioning(providerVersion,
-                    latestVersion,
-                    service.registrarName(),
-                    comparisonResult,
-                    plugin.getVersion().isDevelopmentVersion()
-            );
-        }
-    }
-
-    private static void handleAPIVersioning(
-            EconomyAPIVersion providerVersion,
-            EconomyAPIVersion latestVersion,
-            String registrar,
-            PluginVersion.ComparisonResult comparisonResult,
-            boolean currentVersionDevelopment
-    ) {
-        TreasuryPlugin plugin = TreasuryPlugin.getInstance();
-        PluginVersion.ComparisonResult apiComparisonResult = Utils.compareAPIVersions(providerVersion,
-                latestVersion
-        );
-        if (apiComparisonResult == PluginVersion.ComparisonResult.OLDER) {
-            // this means that "providerVersion" is older than the latest version
-            plugin
-                    .logger()
-                    .error("Economy provider going by the plugin name '" + registrar + "'is utilising an older version of the Treasury Economy API");
-            plugin.logger().error(
-                    "than what your current version of Treasury provides. You should inform the author(s)");
-            plugin.logger().error(
-                    "of that plugin that they should update their resource to use the newer Treasury Economy API");
-            plugin.logger().error(" ");
-            if (comparisonResult == PluginVersion.ComparisonResult.NEWER) {
-                plugin.logger().warn(
-                        "Before updating Treasury, ensure that your Economy Provider utilizes");
-                plugin.logger().warn("the latest version of the Treasury Economy API.");
-                plugin.logger().warn(" ");
-            }
-            plugin.logger().error(
-                    "You must resolve this issue as soon as possible. Leaving this issue unresolved can");
-            plugin.logger().error(
-                    "cause errors with your Economy Provider, and therefore, have the potential to severely harm your server's economy");
-        } else if (apiComparisonResult == PluginVersion.ComparisonResult.NEWER) {
-            // this means that "providerVersion" is newer than the latest version
-            plugin
-                    .logger()
-                    .error("Economy provider going by the plugin name '" + registrar + "'is utilising a newer version of the Treasury Economy API");
-            plugin.logger().error("than what your current version of Treasury provides.");
-            plugin.logger().error(" ");
-            if (comparisonResult == PluginVersion.ComparisonResult.EQUAL) {
-                if (!currentVersionDevelopment) {
-                    plugin.logger().warn(
-                            "Since you seem to be running the latest version of Treasury, please check if your");
-                    plugin.logger().warn(
-                            "Economy Provider expects you to run a development build of Treasury instead of a release build.");
-                } else {
-                    plugin.logger().warn(
-                            "Check if there are any newer development builds available which have a newer Economy API version.");
-                }
-            } else if (comparisonResult == PluginVersion.ComparisonResult.NEWER) {
-                plugin.logger().warn(
-                        "As mentioned up, a Treasury plugin update is available for download - this may resolve");
-                plugin.logger().warn("the mismatching API versions.");
-            } else if (comparisonResult == PluginVersion.ComparisonResult.OLDER) {
-                plugin.logger().warn(
-                        "Check if there are any newer development builds available which have a newer Economy API version.");
-            }
-            plugin.logger().error(" ");
-            plugin.logger().error(
-                    "You must resolve this issue as soon as possible. Leaving this issue unresolved can");
-            plugin.logger().error(
-                    "cause errors with your Economy Provider, and therefore, have the potential to severely harm your server's economy");
         }
     }
 

--- a/core/src/main/java/me/lokka30/treasury/plugin/core/utils/Utils.java
+++ b/core/src/main/java/me/lokka30/treasury/plugin/core/utils/Utils.java
@@ -65,6 +65,13 @@ public class Utils {
         return String.join(delimiter, list);
     }
 
+    /**
+     * Compare two API versions to see if the first version is older/newer.
+     * @param version1 first version to compare
+     * @param version2 second version to compare
+     * @return API versions are no longer used as of Treasury v1.1.0.
+     */
+    @Deprecated
     public static PluginVersion.ComparisonResult compareAPIVersions(
             EconomyAPIVersion version1, EconomyAPIVersion version2
     ) {

--- a/platform/bukkit/api/src/main/java/me/lokka30/treasury/api/economy/event/AccountEvent.java
+++ b/platform/bukkit/api/src/main/java/me/lokka30/treasury/api/economy/event/AccountEvent.java
@@ -13,7 +13,7 @@ import org.jetbrains.annotations.NotNull;
  * Represents an event, holding a {@link Account} of some type.
  *
  * @author MrNemo64
- * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+ * @since v1.0.0
  * @deprecated use {@link me.lokka30.treasury.api.economy.events.AccountTransactionEvent}
  */
 @Deprecated
@@ -31,7 +31,7 @@ public class AccountEvent extends Event {
      * Returns the {@link Account} for this account event.
      *
      * @return account
-     * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+     * @since v1.0.0
      */
     @NotNull
     public Account getAccount() {

--- a/platform/bukkit/api/src/main/java/me/lokka30/treasury/api/economy/event/AccountTransactionEvent.java
+++ b/platform/bukkit/api/src/main/java/me/lokka30/treasury/api/economy/event/AccountTransactionEvent.java
@@ -14,7 +14,7 @@ import org.jetbrains.annotations.NotNull;
  * Represents an event, called when an account does a {@link EconomyTransaction}
  *
  * @author lokka30, MrNemo64
- * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+ * @since v1.0.0
  * @deprecated use {@link me.lokka30.treasury.api.economy.events.AccountTransactionEvent}
  */
 @Deprecated

--- a/platform/bukkit/api/src/main/java/me/lokka30/treasury/api/economy/event/NonPlayerAccountTransactionEvent.java
+++ b/platform/bukkit/api/src/main/java/me/lokka30/treasury/api/economy/event/NonPlayerAccountTransactionEvent.java
@@ -6,14 +6,13 @@ package me.lokka30.treasury.api.economy.event;
 
 import me.lokka30.treasury.api.economy.account.NonPlayerAccount;
 import me.lokka30.treasury.api.economy.transaction.EconomyTransaction;
-import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents an event, called when a {@link NonPlayerAccount} does a {@link EconomyTransaction}
  *
  * @author lokka30
- * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+ * @since v1.0.0
  * @deprecated use {@link me.lokka30.treasury.api.economy.events.NonPlayerAccountTransactionEvent}
  */
 @Deprecated

--- a/platform/bukkit/api/src/main/java/me/lokka30/treasury/api/economy/event/PlayerAccountTransactionEvent.java
+++ b/platform/bukkit/api/src/main/java/me/lokka30/treasury/api/economy/event/PlayerAccountTransactionEvent.java
@@ -6,14 +6,13 @@ package me.lokka30.treasury.api.economy.event;
 
 import me.lokka30.treasury.api.economy.account.PlayerAccount;
 import me.lokka30.treasury.api.economy.transaction.EconomyTransaction;
-import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents an event, called when a {@link PlayerAccount} does a {@link EconomyTransaction}
  *
  * @author lokka30
- * @since {@link me.lokka30.treasury.api.economy.misc.EconomyAPIVersion#v1_0 v1.0}
+ * @since v1.0.0
  * @deprecated use {@link me.lokka30.treasury.api.economy.events.PlayerAccountTransactionEvent}
  */
 @Deprecated

--- a/platform/bukkit/plugin/src/main/java/me/lokka30/treasury/plugin/bukkit/TreasuryBukkit.java
+++ b/platform/bukkit/plugin/src/main/java/me/lokka30/treasury/plugin/bukkit/TreasuryBukkit.java
@@ -13,7 +13,6 @@ import me.lokka30.treasury.api.common.event.EventExecutorTrackerShutdown;
 import me.lokka30.treasury.api.common.services.Service;
 import me.lokka30.treasury.api.common.services.ServiceProvider;
 import me.lokka30.treasury.api.economy.EconomyProvider;
-import me.lokka30.treasury.api.economy.misc.EconomyAPIVersion;
 import me.lokka30.treasury.api.economy.misc.OptionalEconomyApiFeature;
 import me.lokka30.treasury.plugin.bukkit.command.TreasuryCommand;
 import me.lokka30.treasury.plugin.bukkit.event.bukkit2treasury.B2TEventMigrator;
@@ -149,18 +148,6 @@ public class TreasuryBukkit extends JavaPlugin {
                                 .contains(OptionalEconomyApiFeature.BUKKIT_TRANSACTION_EVENTS) || economyProvider
                                 .getSupportedOptionalEconomyApiFeatures()
                                 .contains(OptionalEconomyApiFeature.TRANSACTION_EVENTS))
-        ));
-
-        metrics.addCustomChart(new SimplePie("economy-treasury-api-version", () -> {
-            //noinspection deprecation
-            return EconomyAPIVersion.getCurrentAPIVersion().toString();
-        }));
-
-        metrics.addCustomChart(new SimplePie(
-                "economy-provider-api-version",
-                () -> economyProvider == null
-                        ? null
-                        : economyProvider.getSupportedAPIVersion().toString()
         ));
 
         metrics.addCustomChart(new SimplePie(


### PR DESCRIPTION
I would also like to discuss a target plugin version for the complete removal of all associated classes and methods. :)

I think removing it in v1.2.0 could leave a damaged (albeit little to none) reputation of the library's stability. Perhaps v1.3.0?