### PR TITLE
Fix some thread safety and exception-related problems

### DIFF
--- a/api/src/main/java/me/lokka30/treasury/api/common/event/EventBus.java
+++ b/api/src/main/java/me/lokka30/treasury/api/common/event/EventBus.java
@@ -70,7 +70,7 @@ public enum EventBus {
         List<Class<?>> friends = eventTypes.getFriendsOf(event.getClass());
         ExecutorService async = EventExecutorTracker.INSTANCE.getExecutor(event.getClass());
         FireCompletion<T> ret = new FireCompletion<>(event.getClass());
-        async.submit(() -> {
+        async.execute(() -> {
             List<Completion> completions = new ArrayList<>();
             EventCaller caller = events.get(event.getClass());
             if (caller != null) {

--- a/api/src/main/java/me/lokka30/treasury/api/common/event/EventCaller.java
+++ b/api/src/main/java/me/lokka30/treasury/api/common/event/EventCaller.java
@@ -28,7 +28,7 @@ class EventCaller {
             return Completion.completed();
         }
         Completion completion = new Completion();
-        EventExecutorTracker.INSTANCE.getExecutor(eventClass).submit(() -> {
+        EventExecutorTracker.INSTANCE.getExecutor(eventClass).execute(() -> {
             List<Throwable> errors = call(event, new ArrayList<>(), 0);
             if (!errors.isEmpty()) {
                 completion.completeExceptionally(errors);


### PR DESCRIPTION
1. Regarding EconomyProvider, the previous behavior returned the Set early, before the computations inside the loop necessarily complete. Also, the Set was unsynchronized despite usage in a multithreaded context. Thirdly, `Subscriber#succeed` was called regardless of failure; now, `#succeed` is not called if an exception occurs.
2. Using `ExecutorService#submit` implies the caller will analyze the returned Future for exceptions. While your usages are not intended to throw exceptions, future code refactoring and extreme cases can turn debugging missed exceptions into a hellish experience. Using `#execute` ensures exceptions will at the least be logged.
3. To keep EventBus thread-safe, EventTypeTracker ought likewise to be thread-safe. Thus the `friends` map should be concurrent and atomics performed on it atomic. Additionally, I've simplified the code in the process and removed an unnecessary collect-and-stream operation.

I apologize for not strictly following the contribution process: I became carried away and simply completed all this, before reading the guidelines. However, I think you will find that "people say it sounds good."