### PR TITLE
Make FutureHelper#mapJoinFilter future-friendly

### DIFF
--- a/api/src/main/java/me/lokka30/treasury/api/economy/EconomyProvider.java
+++ b/api/src/main/java/me/lokka30/treasury/api/economy/EconomyProvider.java
@@ -297,7 +297,7 @@ public interface EconomyProvider {
             for (String identifier : identifiers) {
                 futures.add(this.retrieveAccount(identifier));
             }
-            return FutureHelper.mjf(account -> account.isMember(playerId),
+            return FutureHelper.mapJoinFilter(account -> account.isMember(playerId),
                     Account::getIdentifier,
                     futures
             );
@@ -349,7 +349,7 @@ public interface EconomyProvider {
             for (String identifier : identifiers) {
                 accounts.add(this.retrieveAccount(identifier));
             }
-            return FutureHelper.mjf(
+            return FutureHelper.mapJoinFilter(
                     account -> account
                             .hasPermission(playerId, permissions)
                             .thenApply(triState -> triState == TriState.TRUE),

--- a/api/src/main/java/me/lokka30/treasury/api/economy/EconomyProvider.java
+++ b/api/src/main/java/me/lokka30/treasury/api/economy/EconomyProvider.java
@@ -4,9 +4,9 @@
 
 package me.lokka30.treasury.api.economy;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -289,17 +289,17 @@ public interface EconomyProvider {
     @NotNull
     default CompletableFuture<Collection<String>> retrieveAllAccountsPlayerIsMemberOf(@NotNull UUID playerId) {
         Objects.requireNonNull(playerId, "playerId");
-        return this.retrieveAccountIds().thenComposeAsync(identifiers -> {
+        return this.retrieveAccountIds().thenCompose(identifiers -> {
             if (identifiers.isEmpty()) {
                 return CompletableFuture.completedFuture(Collections.emptySet());
             }
-            Collection<CompletableFuture<Account>> futures = new HashSet<>();
+            Collection<CompletableFuture<Account>> accounts = new ArrayList<>(identifiers.size());
             for (String identifier : identifiers) {
-                futures.add(this.retrieveAccount(identifier));
+                accounts.add(this.retrieveAccount(identifier));
             }
             return FutureHelper.mapJoinFilter(account -> account.isMember(playerId),
                     Account::getIdentifier,
-                    futures
+                    accounts
             );
         });
     }
@@ -341,11 +341,11 @@ public interface EconomyProvider {
     ) {
         Objects.requireNonNull(playerId, "playerId");
         Objects.requireNonNull(permissions, "permissions");
-        return this.retrieveAccountIds().thenComposeAsync(identifiers -> {
+        return this.retrieveAccountIds().thenCompose(identifiers -> {
             if (identifiers.isEmpty()) {
                 return CompletableFuture.completedFuture(Collections.emptySet());
             }
-            Collection<CompletableFuture<Account>> accounts = new HashSet<>();
+            Collection<CompletableFuture<Account>> accounts = new ArrayList<>(identifiers.size());
             for (String identifier : identifiers) {
                 accounts.add(this.retrieveAccount(identifier));
             }


### PR DESCRIPTION
I changed a few details with this commit:
* The method implementation no longer blocks.
* Renamed to #mapJoinFilter per other suggestions in #180 .
* Changed the filter parameter to be non-null, since all usages were non-null anyway.