### PR TITLE
EconomyTransactionType#SET

### DIFF
--- a/api/src/main/java/me/lokka30/treasury/api/economy/account/Account.java
+++ b/api/src/main/java/me/lokka30/treasury/api/economy/account/Account.java
@@ -246,21 +246,48 @@ public interface Account {
     /**
      * Reset the {@code Account} balance to its starting amount.
      *
-     * <p>Certain implementations, such as the {@link PlayerAccount}, may default to non-zero starting balances.
+     * <p>Certain implementations, such as the {@link PlayerAccount}, may default to non-zero
+     * starting balances.
      *
      * @param initiator    the one who initiated the transaction
      * @param currency     the {@link Currency} of the balance being reset
+     * @param importance   the reset transaction importance
      * @param subscription the {@link EconomySubscriber} accepting the new balance
-     * @see PlayerAccount#resetBalance(EconomyTransactionInitiator, Currency, EconomySubscriber)
-     * @since v1.0.0
+     * @see #resetBalance(EconomyTransactionInitiator, Currency, EconomyTransactionImportance, String, EconomySubscriber)
+     * @since v2.0.0
      */
     default void resetBalance(
             @NotNull EconomyTransactionInitiator<?> initiator,
             @NotNull Currency currency,
+            @NotNull EconomyTransactionImportance importance,
+            @NotNull EconomySubscriber<BigDecimal> subscription
+    ) {
+        resetBalance(initiator, currency, importance, null, subscription);
+    }
+
+    /**
+     * Reset the {@code Account} balance to its starting amount.
+     *
+     * <p>Certain implementations, such as the {@link PlayerAccount}, may default to non-zero starting balances.
+     *
+     * @param initiator    the one who initiated the transaction
+     * @param currency     the {@link Currency} of the balance being reset
+     * @param importance   the reset transaction importance
+     * @param reason       the reset reason
+     * @param subscription the {@link EconomySubscriber} accepting the new balance
+     * @see PlayerAccount#resetBalance(EconomyTransactionInitiator, Currency, EconomyTransactionImportance, String, EconomySubscriber)
+     * @since v1.0.0 (modified in 2.0.0)
+     */
+    default void resetBalance(
+            @NotNull EconomyTransactionInitiator<?> initiator,
+            @NotNull Currency currency,
+            @NotNull EconomyTransactionImportance importance,
+            @Nullable String reason,
             @NotNull EconomySubscriber<BigDecimal> subscription
     ) {
         Objects.requireNonNull(initiator, "initiator");
         Objects.requireNonNull(currency, "currency");
+        Objects.requireNonNull(importance, "importance");
         Objects.requireNonNull(subscription, "subscription");
 
         doTransaction(EconomyTransaction
@@ -268,8 +295,8 @@ public interface Account {
                 .withCurrency(currency)
                 .withInitiator(initiator)
                 .withTransactionAmount(BigDecimal.ZERO)
-                .withReason("reset")
-                .withImportance(EconomyTransactionImportance.NORMAL)
+                .withReason(reason)
+                .withImportance(importance)
                 .withTransactionType(EconomyTransactionType.SET)
                 .build(), subscription);
     }

--- a/api/src/main/java/me/lokka30/treasury/api/economy/account/Account.java
+++ b/api/src/main/java/me/lokka30/treasury/api/economy/account/Account.java
@@ -9,6 +9,7 @@ import java.time.Instant;
 import java.time.temporal.Temporal;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import me.lokka30.treasury.api.common.misc.TriState;
@@ -68,28 +69,10 @@ public interface Account {
      *
      * @param currency     the {@link Currency} of the balance being requested
      * @param subscription the {@link EconomySubscriber} accepting the amount
-     * @see Account#setBalance(BigDecimal, EconomyTransactionInitiator, Currency, EconomySubscriber)
      * @since v1.0.0
      */
     void retrieveBalance(
             @NotNull Currency currency, @NotNull EconomySubscriber<BigDecimal> subscription
-    );
-
-    /**
-     * Set the balance of the {@code Account}.
-     *
-     * @param amount       the amount the new balance will be
-     * @param initiator    the one who initiated the transaction
-     * @param currency     the {@link Currency} of the balance being set
-     * @param subscription the {@link EconomySubscriber} accepting the new balance
-     * @see Account#retrieveBalance(Currency, EconomySubscriber)
-     * @since v1.0.0
-     */
-    void setBalance(
-            @NotNull BigDecimal amount,
-            @NotNull EconomyTransactionInitiator<?> initiator,
-            @NotNull Currency currency,
-            @NotNull EconomySubscriber<BigDecimal> subscription
     );
 
     /**
@@ -99,7 +82,6 @@ public interface Account {
      * @param initiator    the one who initiated the transaction
      * @param currency     the {@link Currency} of the balance being modified
      * @param subscription the {@link EconomySubscriber} accepting the new balance
-     * @see Account#setBalance(BigDecimal, EconomyTransactionInitiator, Currency, EconomySubscriber)
      * @see Account#doTransaction(EconomyTransaction, EconomySubscriber)
      * @since v1.0.0
      */
@@ -127,7 +109,6 @@ public interface Account {
      * @param currency     the {@link Currency} of the balance being modified
      * @param importance   how important is the transaction
      * @param subscription the {@link EconomySubscriber} accepting the new balance
-     * @see Account#setBalance(BigDecimal, EconomyTransactionInitiator, Currency, EconomySubscriber)
      * @see Account#doTransaction(EconomyTransaction, EconomySubscriber)
      * @since v1.0.0
      */
@@ -150,7 +131,6 @@ public interface Account {
      * @param importance   how important is the transaction
      * @param reason       the reason of why the balance is modified
      * @param subscription the {@link EconomySubscriber} accepting the new balance
-     * @see Account#setBalance(BigDecimal, EconomyTransactionInitiator, Currency, EconomySubscriber)
      * @see Account#doTransaction(EconomyTransaction, EconomySubscriber)
      * @since v1.0.0
      */
@@ -180,7 +160,6 @@ public interface Account {
      * @param initiator    the one who initiated the transaction
      * @param currency     the {@link Currency} of the balance being modified
      * @param subscription the {@link EconomySubscriber} accepting the new balance
-     * @see Account#setBalance(BigDecimal, EconomyTransactionInitiator, Currency, EconomySubscriber)
      * @see Account#doTransaction(EconomyTransaction, EconomySubscriber)
      * @since v1.0.0
      */
@@ -208,7 +187,6 @@ public interface Account {
      * @param currency     the {@link Currency} of the balance being modified
      * @param importance   how important is the transaction
      * @param subscription the {@link EconomySubscriber} accepting the new balance
-     * @see Account#setBalance(BigDecimal, EconomyTransactionInitiator, Currency, EconomySubscriber)
      * @see Account#doTransaction(EconomyTransaction, EconomySubscriber)
      * @since v1.0.0
      */
@@ -231,7 +209,6 @@ public interface Account {
      * @param importance   how important is the transaction
      * @param reason       the reason of why the balance is modified
      * @param subscription the {@link EconomySubscriber} accepting the new balance
-     * @see Account#setBalance(BigDecimal, EconomyTransactionInitiator, Currency, EconomySubscriber)
      * @see Account#doTransaction(EconomyTransaction, EconomySubscriber)
      * @since v1.0.0
      */
@@ -259,7 +236,6 @@ public interface Account {
      *
      * @param economyTransaction the transaction that should be done
      * @param subscription       the {@link EconomySubscriber} accepting the new balance
-     * @see Account#setBalance(BigDecimal, EconomyTransactionInitiator, Currency, EconomySubscriber)
      * @since v1.0.0
      */
     void doTransaction(
@@ -276,7 +252,6 @@ public interface Account {
      * @param currency     the {@link Currency} of the balance being reset
      * @param subscription the {@link EconomySubscriber} accepting the new balance
      * @see PlayerAccount#resetBalance(EconomyTransactionInitiator, Currency, EconomySubscriber)
-     * @see Account#setBalance(BigDecimal, EconomyTransactionInitiator, Currency, EconomySubscriber)
      * @since v1.0.0
      */
     default void resetBalance(
@@ -284,17 +259,19 @@ public interface Account {
             @NotNull Currency currency,
             @NotNull EconomySubscriber<BigDecimal> subscription
     ) {
-        setBalance(BigDecimal.ZERO, initiator, currency, new EconomySubscriber<BigDecimal>() {
-            @Override
-            public void succeed(@NotNull BigDecimal value) {
-                subscription.succeed(BigDecimal.ZERO);
-            }
+        Objects.requireNonNull(initiator, "initiator");
+        Objects.requireNonNull(currency, "currency");
+        Objects.requireNonNull(subscription, "subscription");
 
-            @Override
-            public void fail(@NotNull EconomyException exception) {
-                subscription.fail(exception);
-            }
-        });
+        doTransaction(EconomyTransaction
+                .newBuilder()
+                .withCurrency(currency)
+                .withInitiator(initiator)
+                .withTransactionAmount(BigDecimal.ZERO)
+                .withReason("reset")
+                .withImportance(EconomyTransactionImportance.NORMAL)
+                .withTransactionType(EconomyTransactionType.SET)
+                .build(), subscription);
     }
 
     /**

--- a/api/src/main/java/me/lokka30/treasury/api/economy/account/PlayerAccount.java
+++ b/api/src/main/java/me/lokka30/treasury/api/economy/account/PlayerAccount.java
@@ -17,7 +17,10 @@ import me.lokka30.treasury.api.economy.currency.Currency;
 import me.lokka30.treasury.api.economy.response.EconomyException;
 import me.lokka30.treasury.api.economy.response.EconomyFailureReason;
 import me.lokka30.treasury.api.economy.response.EconomySubscriber;
+import me.lokka30.treasury.api.economy.transaction.EconomyTransaction;
+import me.lokka30.treasury.api.economy.transaction.EconomyTransactionImportance;
 import me.lokka30.treasury.api.economy.transaction.EconomyTransactionInitiator;
+import me.lokka30.treasury.api.economy.transaction.EconomyTransactionType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -161,18 +164,15 @@ public interface PlayerAccount extends Account {
         Objects.requireNonNull(currency, "currency");
         Objects.requireNonNull(subscription, "subscription");
 
-        final BigDecimal newBalance = currency.getStartingBalance(getUniqueId());
-        setBalance(newBalance, initiator, currency, new EconomySubscriber<BigDecimal>() {
-            @Override
-            public void succeed(@NotNull BigDecimal value) {
-                subscription.succeed(newBalance);
-            }
-
-            @Override
-            public void fail(@NotNull EconomyException exception) {
-                subscription.fail(exception);
-            }
-        });
+        doTransaction(EconomyTransaction
+                .newBuilder()
+                .withCurrency(currency)
+                .withInitiator(initiator)
+                .withTransactionAmount(currency.getStartingBalance(getUniqueId()))
+                .withReason("reset")
+                .withImportance(EconomyTransactionImportance.NORMAL)
+                .withTransactionType(EconomyTransactionType.SET)
+                .build(), subscription);
     }
 
 }

--- a/api/src/main/java/me/lokka30/treasury/api/economy/account/PlayerAccount.java
+++ b/api/src/main/java/me/lokka30/treasury/api/economy/account/PlayerAccount.java
@@ -151,17 +151,20 @@ public interface PlayerAccount extends Account {
      * @param initiator    the one who initiated this transaction
      * @param currency     of the balance being reset
      * @param subscription the {@link EconomySubscriber} accepting the new balance
-     * @see Account#resetBalance(EconomyTransactionInitiator, Currency, EconomySubscriber)
+     * @see Account#resetBalance(EconomyTransactionInitiator, Currency, EconomyTransactionImportance, String, EconomySubscriber)
      * @since v1.0.0
      */
     @Override
     default void resetBalance(
             @NotNull EconomyTransactionInitiator<?> initiator,
             @NotNull Currency currency,
+            @NotNull EconomyTransactionImportance importance,
+            @Nullable String reason,
             @NotNull EconomySubscriber<BigDecimal> subscription
     ) {
         Objects.requireNonNull(initiator, "initiator");
         Objects.requireNonNull(currency, "currency");
+        Objects.requireNonNull(importance, "importance");
         Objects.requireNonNull(subscription, "subscription");
 
         doTransaction(EconomyTransaction
@@ -169,8 +172,8 @@ public interface PlayerAccount extends Account {
                 .withCurrency(currency)
                 .withInitiator(initiator)
                 .withTransactionAmount(currency.getStartingBalance(getUniqueId()))
-                .withReason("reset")
-                .withImportance(EconomyTransactionImportance.NORMAL)
+                .withReason(reason)
+                .withImportance(importance)
                 .withTransactionType(EconomyTransactionType.SET)
                 .build(), subscription);
     }

--- a/api/src/main/java/me/lokka30/treasury/api/economy/transaction/EconomyTransactionType.java
+++ b/api/src/main/java/me/lokka30/treasury/api/economy/transaction/EconomyTransactionType.java
@@ -25,6 +25,13 @@ public enum EconomyTransactionType {
      *
      * @since v1.0.0
      */
-    WITHDRAWAL
+    WITHDRAWAL,
+
+    /**
+     * The Account's new balance is set. Can be more or less than their previous balance.
+     *
+     * @since 2.0.0
+     */
+    SET
 
 }

--- a/api/src/main/java/me/lokka30/treasury/api/economy/transaction/EconomyTransactionType.java
+++ b/api/src/main/java/me/lokka30/treasury/api/economy/transaction/EconomyTransactionType.java
@@ -28,7 +28,7 @@ public enum EconomyTransactionType {
     WITHDRAWAL,
 
     /**
-     * The Account's new balance is set. Can be more or less than their previous balance.
+     * The Account's balance is adjusted to a specified value.
      *
      * @since 2.0.0
      */


### PR DESCRIPTION
Closes #198 

Removed `setBalance` method in order to force the use of `doTransaction`
Didn't directly push because needs discussion about shall we create a `resetBalance` method with a reason and a importance.