### PR TITLE
Always check for classes on BukkitVendor

### DIFF
--- a/platform/bukkit/src/main/java/me/lokka30/treasury/plugin/bukkit/vendor/BukkitVendor.java
+++ b/platform/bukkit/src/main/java/me/lokka30/treasury/plugin/bukkit/vendor/BukkitVendor.java
@@ -5,7 +5,6 @@
 package me.lokka30.treasury.plugin.bukkit.vendor;
 
 import me.lokka30.treasury.plugin.core.Platform;
-import org.bukkit.Bukkit;
 
 /**
  * Represents a handler for determining on what server vendor we're running. This is in order
@@ -44,18 +43,30 @@ public final class BukkitVendor {
     }
 
     /**
+     * Returns whether we're running any of the specified classes.
+     *
+     * @param classNames the class names to check for
+     * @return any of the specified classes?
+     */
+    private static boolean hasClass(String... classNames) {
+        for (String className : classNames) {
+            try {
+                Class.forName(className);
+                return true;
+            } catch (ClassNotFoundException ignored) {
+            }
+        }
+        return false;
+    }
+
+    /**
      * Returns whether we're running spigot.
      *
      * @return spigot?
      */
     public static boolean isSpigot() {
         if (!ranSpigotCheck) {
-            try {
-                Class.forName("net.md_5.bungee.api.chat.ChatColor");
-                spigot = true;
-            } catch (ClassNotFoundException e) {
-                spigot = false;
-            }
+            spigot = hasClass("org.spigotmc.SpigotConfig");
             ranSpigotCheck = true;
         }
         return spigot;
@@ -68,7 +79,10 @@ public final class BukkitVendor {
      */
     public static boolean isPaper() {
         if (!ranPaperCheck) {
-            paper = Bukkit.getName().equalsIgnoreCase("Paper");
+            paper = hasClass(
+                    "com.destroystokyo.paper.PaperConfig",
+                    "io.papermc.paper.configuration.Configuration"
+            );
             ranPaperCheck = true;
         }
         return paper;
@@ -81,7 +95,7 @@ public final class BukkitVendor {
      */
     public static boolean isFolia() {
         if (!ranFoliaCheck) {
-            folia = Bukkit.getName().equalsIgnoreCase("Folia");
+            folia = hasClass("io.papermc.paper.threadedregions.RegionizedServer");
             ranFoliaCheck = true;
         }
         return folia;


### PR DESCRIPTION
This ultimately fixes a case where it fails to check Folia vendor if the server is running on a fork of Folia (like [Kaiiju](https://github.com/KaiijuMC/Kaiiju)).
This also changed the target classes based on [PaperLib](https://github.com/PaperMC/PaperLib/blob/69e76fc9036e7b5f2c967bd21db31043724ef9e3/src/main/java/io/papermc/lib/PaperLib.java#L37-L45) and my own [HSCore](https://github.com/HSGamer/HSCore/blob/master/hscore-bukkit/hscore-bukkit-folia/src/main/java/me/hsgamer/hscore/bukkit/folia/FoliaChecker.java) (which is based on a discussion on PaperMC's Discord server)

P/S: Yes, they did port some classes from Folia back to Paper, but only [the Scheduler & Owner Region API](https://github.com/PaperMC/Paper/blob/master/patches/server/0972-Folia-scheduler-and-owned-region-API.patch). Therefore, the old class checks are still relevant.